### PR TITLE
Fix color not being applied to `#user-info`

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,11 +217,14 @@
 
       #user-info {
         background-color: #FF3232;
-        color: #FFE9E9;
         padding: 8px;
         display: flex;
         flex-direction: column;
         gap: 8px;
+      }
+
+      #user-info > p {
+        color: #FFE9E9;
       }
 
       #user-name {


### PR DESCRIPTION
The white color in the `#user-info` menu is not being applied correctly, currently it looks like this

![image](https://github.com/KittyCAD/cookie-cutter/assets/53809656/5caea5b8-3c33-49ac-898f-70bc2ff15258)

From looking at the figma design file, it's not supposed to look like that
![Frame 8](https://github.com/KittyCAD/cookie-cutter/assets/53809656/43e91782-3621-4dcd-9b9c-6b95bed2a514)

The color is not being correctly applied because the `color` property is set on the container `#user-info` at [line 220](https://github.com/KittyCAD/cookie-cutter/blob/57a4d5ccbf52f4edcf78c85780a6bfe00a986f41/index.html#L220)

```css
#user-info {
  background-color: #FF3232;
  color: #FFE9E9; /* <---- HERE */
  padding: 8px;
  display: flex;
  flex-direction: column;
  gap: 8px;
}
```

But if we look up the file a little we will find another declaration the overrides that at [line 69](https://github.com/KittyCAD/cookie-cutter/blob/57a4d5ccbf52f4edcf78c85780a6bfe00a986f41/index.html#L69)

```css
p {
  font-family: "Owners", sans-serif;
  font-size: 16px;
  color: #FF0000; /* <---- HERE */
}
```

The PR fixes this by applying the color rule to all the immediate `p` tags under `#user-info`
```css
#user-info > p {
  color: #FFE9E9;
}
```

After this fix, the `#user-info` menu looks like this

![image](https://github.com/KittyCAD/cookie-cutter/assets/53809656/00a6089e-675c-4e70-832f-aa1361711d89)
